### PR TITLE
Use uint32 instead of int i public api

### DIFF
--- a/RingBuffer.fs
+++ b/RingBuffer.fs
@@ -7,7 +7,8 @@ type RingBuffer<'a> =
   private {putCh : Ch<'a>; takeCh : Ch<'a>; takeBatchCh : Ch<int*IVar<'a[]>>}
 
 module RingBuffer =
-  let create ringSize : Job<RingBuffer<'a>> =
+  let create (ringSize : uint32) : Job<RingBuffer<'a>> =
+    let ringSize = int ringSize
     let self = { putCh = Ch (); takeCh = Ch (); takeBatchCh = Ch () }
     let ring = Array.zeroCreate ringSize
     let limit = ringSize - 1
@@ -21,7 +22,7 @@ module RingBuffer =
       tail <- modulo <| tail + 1
     let inline count () =
       modulo <| ringSize + head - tail
-    let dequeueBatch (max,ivar) =
+    let dequeueBatch (max, ivar) =
       let dequeueCount = min max <| count ()
       let arr = Array.zeroCreate dequeueCount
       let stopIndex = tail + dequeueCount
@@ -47,8 +48,8 @@ module RingBuffer =
     Job.foreverServer proc >>-. self
   let put q x = q.putCh *<- x
   let take q = q.takeCh :> Alt<_>
-  let takeBatch maxBatchSize q = q.takeBatchCh *<-=>- (fun iv -> maxBatchSize, iv) 
-  let takeAll q = takeBatch System.Int32.MaxValue q
+  let takeBatch (maxBatchSize : uint32) q = q.takeBatchCh *<-=>- (fun iv -> int maxBatchSize, iv) 
+  let takeAll q = takeBatch System.UInt32.MaxValue q
 
   let consume q s = Stream.iterJob (fun x -> q.putCh *<- x) s |> Job.start
   let tap q = Stream.indefinitely <| q.takeCh


### PR DESCRIPTION
@neoeinstein I've done some updates which change the public API. We're going to merge this into Logary, but we can back-pedal if you have objections.
